### PR TITLE
- GPU Code section profiling works only if the number of profiled sections does not decrease

### DIFF
--- a/src/org/lwjglx/debug/RT.java
+++ b/src/org/lwjglx/debug/RT.java
@@ -1212,7 +1212,10 @@ public class RT {
             section = ctx.codeSectionTimes.get(ctx.currentCodeSectionIndex);
             if (section == null || !section.name.equals(string)) {
                 for (int i = ctx.currentCodeSectionIndex + 1; i < ctx.codeSectionTimes.size(); i++) {
-                    ctx.codeSectionTimes.set(i, null);
+//                    If the number of codeSectionTimes gets smaller, this will lead to a NP exception later on.
+//                    Use Case: Profile 5 codeSections at frame n. Profile only 4 code sections in frame n+1.
+//                    ctx.codeSectionTimes.set(i, null);
+                    ctx.codeSectionTimes.remove(i);
                 }
                 section = new TimedCodeSection();
                 section.name = string;


### PR DESCRIPTION
GPU Code section profiling works only if the number of profiled sections does not decrease from one frame to the next. If so, a NP-exception is thrown @Profiling.frame() -> l:179 String name = section.name; as sections are set to null in RT.stringMarker(String) -> l:1215 ctx.codeSectionTimes.set(i, null); replacing this line with ctx.codeSectionTimes.remove(i); solves the issue.

Use Case: Profile 5 codeSections at frame n. Profile only 4 code sections in frame n+1.