### PR TITLE
Fix Java 8 Compatibility Issue.

### DIFF
--- a/src/org/lwjglx/debug/Profiling.java
+++ b/src/org/lwjglx/debug/Profiling.java
@@ -120,7 +120,7 @@ class Profiling {
         context.setWelcomeFiles(new String[] { "index.html" });
         server.setHandler(context);
 
-        WebSocketUpgradeFilter wsfilter = WebSocketUpgradeFilter.configureContext(context);
+        WebSocketUpgradeFilter wsfilter = WebSocketUpgradeFilter.configure(context);
         // wsfilter.getFactory().getPolicy().setIdleTimeout(5000);
         wsfilter.addMapping(new ServletPathSpec("/ws"), new ProfilingConnectionCreator());
 

--- a/src/org/lwjglx/debug/Profiling.java
+++ b/src/org/lwjglx/debug/Profiling.java
@@ -1,5 +1,6 @@
 package org.lwjglx.debug;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ class EchoSocketServlet extends WebSocketServlet {
 class ProfilingConnection implements WebSocketListener {
     public static final List<ProfilingConnection> connections = new ArrayList<>();
     Session outbound;
-    ByteBuffer buffer = ByteBuffer.allocateDirect(1024).order(ByteOrder.BIG_ENDIAN);
+    Buffer buffer = ByteBuffer.allocateDirect(1024).order(ByteOrder.BIG_ENDIAN);
     long bufferAddr = MemoryUtil.memAddress0(buffer);
     Future<Void> lastSend = null;
 
@@ -61,7 +62,7 @@ class ProfilingConnection implements WebSocketListener {
         MemoryUtil.memCopy(addr, bufferAddr, size);
         buffer.rewind();
         buffer.limit(size);
-        lastSend = outbound.getRemote().sendBytesByFuture(buffer);
+        lastSend = outbound.getRemote().sendBytesByFuture((ByteBuffer) buffer);
     }
 
     public void onWebSocketClose(int statusCode, String reason) {


### PR DESCRIPTION
Issue:
If we compile this class with JDK13(or any JDK releases after JDK8), and running it with JDK8, it produces a exception like below:
    "Exception in thread "main" java.lang.NoSuchMethodError: java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;"

Cause:
The ByteBuffer override method rewind with a different return type ByteBuffer Since JDK9.When bytecodes generated by JDK13 and running with Java8, JVM will try to find a method match the method descriptor "java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer" and it will fail.